### PR TITLE
Use websocket via HTTPS if appropriate

### DIFF
--- a/src/mopidy.js
+++ b/src/mopidy.js
@@ -57,8 +57,10 @@ Mopidy.prototype._getConsole = function (settings) {
 Mopidy.prototype._configure = function (settings) {
     var currentHost = (typeof document !== "undefined" &&
         document.location.host) || "localhost";
+    var protocol = (typeof document !== "undefined" &&
+        document.location.protocol === "https:") ? "wss://" : "ws://";
     settings.webSocketUrl = settings.webSocketUrl ||
-        "ws://" + currentHost + "/mopidy/ws";
+        protocol + currentHost + "/mopidy/ws";
 
     if (settings.autoConnect !== false) {
         settings.autoConnect = true;


### PR DESCRIPTION
If the page was loaded via HTTPS, the websocket should also connect via HTTPS. Fixes mopidy/mopidy#950.