### PR TITLE
Reimplement most .off() variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,8 +75,6 @@
     Subscribe to more specific events using `mopidy.on(event, listener)`.
   - `mopidy.off(listener)` --
     Unsubscribe from specific events using `mopidy.off(event, listener)`.
-  - `mopidy.off(event)` --
-    Unsubscribe specific listeners using `mopidy.off(event, listener)`.
   - `mopidy.bind(...)`
   - `mopidy.errback(listener)`
 
@@ -84,9 +82,9 @@
 
   - `mopidy.on(event, listener)`
   - `mopidy.once(event, listener)`
-  - `mopidy.off(event, listener)` -- Note that Node.js only added
-    this method in Node.js 10.0.0. Consider upgrading Node.js or replacing
-    `mopidy.off()` with `mopidy.removeListener()`.
+  - `mopidy.off(event, listener)`
+  - `mopidy.off(event)`
+  - `mopidy.off()`
   - `mopidy.emit(event, ...)`
 
 - For exploring what events Mopidy.js emits, two new aggregate event types

--- a/src/mopidy.js
+++ b/src/mopidy.js
@@ -67,6 +67,23 @@ class Mopidy extends EventEmitter {
     this.on("state:offline", this._reconnect);
   }
 
+  off(...args) {
+    if (args.length === 0) {
+      this.removeAllListeners();
+    } else if (args.length === 1) {
+      const arg = args[0];
+      if (typeof arg === "string") {
+        this.removeAllListeners(arg);
+      } else {
+        throw Error(
+          "Expected no arguments, a string, or a string and a listener."
+        );
+      }
+    } else {
+      this.removeListener(...args);
+    }
+  }
+
   connect() {
     if (this._webSocket) {
       if (this._webSocket.readyState === Mopidy.WebSocket.OPEN) {
@@ -128,7 +145,7 @@ class Mopidy extends EventEmitter {
   }
 
   close() {
-    this.removeListener("state:offline", this._reconnect);
+    this.off("state:offline", this._reconnect);
     if (this._webSocket) {
       this._webSocket.close();
     }

--- a/test/mopidy.test.js
+++ b/test/mopidy.test.js
@@ -65,6 +65,49 @@ describe("constructor", () => {
   });
 });
 
+describe(".off", () => {
+  test("with no args works", () => {
+    const removeAllStub = jest.spyOn(this.mopidy, "removeAllListeners");
+
+    this.mopidy.off();
+
+    expect(removeAllStub).toBeCalledWith();
+  });
+
+  test("with an event name works", () => {
+    const removeAllStub = jest.spyOn(this.mopidy, "removeAllListeners");
+
+    this.mopidy.off("some-event");
+
+    expect(removeAllStub).toBeCalledWith("some-event");
+  });
+
+  test("with a listener fails", () => {
+    const listener = () => {};
+    const removeAllStub = jest.spyOn(this.mopidy, "removeAllListeners");
+
+    try {
+      this.mopidy.off(listener);
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe(
+        "Expected no arguments, a string, or a string and a listener."
+      );
+    }
+
+    expect(removeAllStub).not.toBeCalled();
+  });
+
+  test("with an event name and a listener works", () => {
+    const listener = () => {};
+    const removeStub = jest.spyOn(this.mopidy, "removeListener");
+
+    this.mopidy.off("some-event", listener);
+
+    expect(removeStub).toBeCalledWith("some-event", listener);
+  });
+});
+
 describe(".connect", () => {
   test("connects when autoConnect is false", () => {
     const mopidy = new Mopidy({
@@ -331,7 +374,7 @@ describe("._resetBackoffDelay", () => {
 
 describe(".close", () => {
   test("unregisters reconnection hooks", () => {
-    const spy = jest.spyOn(this.mopidy, "removeListener");
+    const spy = jest.spyOn(this.mopidy, "off");
 
     this.mopidy.close();
 


### PR DESCRIPTION
To ease migration from Mopidy 0.5, this reimplements the various ways of calling `.off()` that can easily be implemented using `.removeAllListeners()` and `.removeListener`().

@tkem Re #17, does this ease the migration from v0.5 for you?