### PR TITLE
Fix for TypeError: Cannot read property '_console' of undefined

### DIFF
--- a/src/mopidy.js
+++ b/src/mopidy.js
@@ -248,7 +248,7 @@ class Mopidy extends EventEmitter {
   _getApiSpec() {
     return this._send({ method: "core.describe" })
       .then(this._createApi.bind(this))
-      .catch(this._handleWebSocketError);
+      .catch(this._handleWebSocketError.bind(this));
   }
 
   _createApi(methods) {


### PR DESCRIPTION
Error was detected during unit testing.
The temporary created WebSocket server was closed right after mopidy.js fired "websocket:open" event.