### PR TITLE
Add setImmediate polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11734,8 +11734,7 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "isomorphic-ws": "^4.0.1",
+    "setimmediate": "^1.0.5",
     "ws": "^7.2.3"
   },
   "devDependencies": {

--- a/src/mopidy.js
+++ b/src/mopidy.js
@@ -1,3 +1,4 @@
+require("setimmediate");
 const EventEmitter = require("events");
 const WebSocket = require("isomorphic-ws");
 


### PR DESCRIPTION
This increases the gzipped size of mopidy.js from 16.25 kB to 19.7 kB, so robust alternatives are welcome.

Fixes #30