### PR TITLE
Add TypeScript definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.0] - UNRELEASED
+
+- Add TypeScript definitions. (Fixes: #27, #33)
+
 ## [1.1.1] - 2020-09-10
 
 - Replace `setImmediate(fn)` usage with `setTimeout(fn, 0)` as

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "bugs": "https://github.com/mopidy/mopidy.js/issues",
   "license": "Apache-2.0",
   "main": "src/mopidy.js",
+  "types": "src/mopidy.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/mopidy/mopidy.js"

--- a/src/mopidy.d.ts
+++ b/src/mopidy.d.ts
@@ -679,10 +679,10 @@ declare namespace Mopidy {
         /**
          * the time position in milliseconds
          */
-        timePosition,
+        time_position,
       }: {
         tl_track: models.TlTrack;
-        timePosition: number;
+        time_position: number;
       }) => void;
       /**
        * Called whenever track playback is paused.
@@ -695,10 +695,10 @@ declare namespace Mopidy {
         /**
          * the time position in milliseconds
          */
-        timePosition,
+        time_position,
       }: {
         tl_track: models.TlTrack;
-        timePosition: number;
+        time_position: number;
       }) => void;
       /**
        * Called whenever track playback is resumed.
@@ -711,10 +711,10 @@ declare namespace Mopidy {
         /**
          * the time position in milliseconds
          */
-        timePosition,
+        time_position,
       }: {
         tl_track: models.TlTrack;
-        timePosition: number;
+        time_position: number;
       }) => void;
       /**
        * Called whenever a new track starts playing.

--- a/src/mopidy.d.ts
+++ b/src/mopidy.d.ts
@@ -1,93 +1,627 @@
-// Type definitions for Mopidy.js v1.0.1, Mopidy v3.0.1 WebSocket API
+// Type definitions for Mopidy.js v1.1.0, Mopidy v3.0.2 WebSocket API
 
-declare module "mopidy" {
-    type ValueOf<T> = T[keyof T];
+export = Mopidy
 
-    export interface Options {
-      /**
-       * URL used when creating new WebSocket objects.
-       *
-       * In a browser environment, it defaults to
-       * ws://${document.location.host}/mopidy/ws. If the current page is served
-       * over HTTPS, it defaults to using wss:// instead of ws://.
-       *
-       * In a non-browser environment, where document.location isn't available, it
-       * defaults to ws://localhost/mopidy/ws.
-       */
-      webSocketUrl: string;
-      /**
-       * Whether or not to connect to the WebSocket on instance creation. Defaults
-       * to true.
-       */
-      autoConnect?: boolean;
-      /**
-       * The minimum number of milliseconds to wait after a connection error before
-       * we try to reconnect. For every failed attempt, the backoff delay is doubled
-       * until it reaches backoffDelayMax. Defaults to 1000.
-       */
-      backoffDelayMin?: number;
-      /**
-       * The maximum number of milliseconds to wait after a connection error before
-       * we try to reconnect. Defaults to 64000.
-       */
-      backoffDelayMax?: number;
-      /**
-       * If set, this object will be used to log errors from Mopidy.js. This is
-       * mostly useful for testing Mopidy.js. Defaults to console.
-       */
-      console?: Object;
-      /**
-       * An existing WebSocket object to be used instead of creating a new
-       * WebSocket. Defaults to undefined.
-       */
-      webSocket?: WebSocket;
-      /**
-       * Controls whether the JSON-RPC API is passed arguments as arrays or named
-       * objects. The only verison that is supported by this typing file is named
-       * objects.
-       */
-      callingConvention?: "by-name-only";
+declare class Mopidy {
+  // ----------------- MOPIDY.JS-SPECIFIC API -----------------
+
+  /**
+   * Mopidy.js is a JavaScript library for controlling a Mopidy music server.
+   *
+   * The library makes Mopidy's core API available from browsers and Node.js
+   * programs, using JSON-RPC over a WebSocket to communicate with Mopidy.
+   *
+   * This library is the foundation of most Mopidy web clients.
+   */
+  constructor(options: Mopidy.Options);
+  /**
+   * Explicit connect function for when autoConnect:false is passed to
+   * constructor.
+   */
+  connect(): Promise<void>;
+  /**
+   * Close the WebSocket without reconnecting. Letting the object be garbage
+   * collected will have the same effect, so this isn't strictly necessary.
+   */
+  close(): Promise<void>;
+
+  // ----------------- EVENT SUBSCRIPTION -----------------
+
+  on<K extends keyof Mopidy.StrictEvents>(
+    name: K, listener: Mopidy.StrictEvents[K]
+  ): this;
+
+  off(): void;
+  off<K extends keyof Mopidy.StrictEvents>(
+    name: K, listener: Mopidy.StrictEvents[K]
+ ): this;
+
+  // ----------------- CORE API -----------------
+
+  /**
+   * Manages everything related to the list of tracks we will play. See
+   * TracklistController. Undefined before Mopidy connects.
+   */
+  tracklist: Mopidy.Core.TracklistController | undefined;
+  /**
+   * Manages playback state and the current playing track. See
+   * PlaybackController. Undefined before Mopidy connects.
+   */
+  playback: Mopidy.Core.PlaybackController | undefined;
+  /**
+   * Manages the music library, e.g. searching and browsing for music. See
+   * LibraryController. Undefined before Mopidy connects.
+   */
+  library: Mopidy.Core.LibraryController | undefined;
+  /**
+   * Manages stored playlists. See PlaylistsController. Undefined before
+   * Mopidy connects.
+   */
+  playlists: Mopidy.Core.PlaylistsController | undefined;
+  /**
+   * Manages volume and muting. See MixerController. Undefined before Mopidy
+   * connects.
+   */
+  mixer: Mopidy.Core.MixerController | undefined;
+  /**
+   * Keeps record of what tracks have been played. See HistoryController.
+   * Undefined before Mopidy connects.
+   */
+  history: Mopidy.Core.HistoryController | undefined;
+
+  /**
+   * Get list of URI schemes we can handle
+   */
+  getUriSchemes(): Promise<string[]>;
+  /**
+   * Get version of the Mopidy core API
+   */
+  getVersion(): Promise<string>;
+}
+
+declare namespace Mopidy {
+  type ValueOf<T> = T[keyof T];
+
+  interface Options {
+    /**
+     * URL used when creating new WebSocket objects.
+     *
+     * In a browser environment, it defaults to
+     * ws://${document.location.host}/mopidy/ws. If the current page is served
+     * over HTTPS, it defaults to using wss:// instead of ws://.
+     *
+     * In a non-browser environment, where document.location isn't available, it
+     * defaults to ws://localhost/mopidy/ws.
+     */
+    webSocketUrl: string;
+    /**
+     * Whether or not to connect to the WebSocket on instance creation. Defaults
+     * to true.
+     */
+    autoConnect?: boolean;
+    /**
+     * The minimum number of milliseconds to wait after a connection error before
+     * we try to reconnect. For every failed attempt, the backoff delay is doubled
+     * until it reaches backoffDelayMax. Defaults to 1000.
+     */
+    backoffDelayMin?: number;
+    /**
+     * The maximum number of milliseconds to wait after a connection error before
+     * we try to reconnect. Defaults to 64000.
+     */
+    backoffDelayMax?: number;
+    /**
+     * If set, this object will be used to log errors from Mopidy.js. This is
+     * mostly useful for testing Mopidy.js. Defaults to console.
+     */
+    console?: Console;
+    /**
+     * An existing WebSocket object to be used instead of creating a new
+     * WebSocket. Defaults to undefined.
+     */
+    webSocket?: WebSocket;
+  }
+  type URI = string;
+  type PlaybackState = "playing" | "paused" | "stopped";
+  type QueryField =
+    | "uri"
+    | "track_name"
+    | "album"
+    | "artist"
+    | "albumartist"
+    | "composer"
+    | "performer"
+    | "track_no"
+    | "genre"
+    | "date"
+    | "comment"
+    | "any";
+  type Query = { [key in QueryField]?: string[] };
+  interface StrictEvents extends Core.CoreListener {
+    /**
+     * Client state
+     *
+     * You can get notified about when the Mopidy.js client is connected to the
+     * server and ready for method calls, when it's offline, and when it's
+     * trying to reconnect to the server by looking at the events
+     */
+    "state:online": () => void;
+    "state:offline": () => void;
+    reconnectionPending: ({ timeToAttempt }: { timeToAttempt: number }) => void;
+    reconnecting: () => void;
+    /**
+     * The client state events are also emitted under the aggregate event named
+     * state.
+     */
+    state: (args?: unknown) => void;
+
+    /**
+     * WebSocket events
+     *
+     * You can introspect what happens internally on the WebSocket by looking at
+     * the events.
+     *
+     * Of course, you can also do this using the web developer tools in any
+     * modern browser.
+     */
+    "websocket:close": any;
+    "websocket:error": any;
+    "websocket:incomingMessage": any;
+    "websocket:open": any;
+    "websocket:outgoingMessage": any;
+  }
+
+  // https://docs.mopidy.com/en/latest/api/models/
+  type ModelType =
+    | "album"
+    | "artist"
+    | "directory"
+    | "playlist"
+    | "track";
+  namespace models {
+    class Ref<T extends ModelType> {
+      constructor({ uri, name, type }: { uri: URI; name: string; type: T });
+      static album(): Ref<"album">;
+      static artist(): Ref<"artist">;
+      static directory(): Ref<"directory">;
+      static playlist(): Ref<"playlist">;
+      static track(): Ref<"track">;
+      static ALBUM: "album";
+      static ARTIST: "artist";
+      static DIRECTORY: "directory";
+      static PLAYLIST: "playlist";
+      static TRACK: "track";
+      readonly name: string;
+      readonly type: T;
+      readonly uri: URI;
     }
-    export type URI = string;
-    export type PlaybackState = "playing" | "paused" | "stopped";
-    export type QueryField =
-      | "uri"
-      | "track_name"
-      | "album"
-      | "artist"
-      | "albumartist"
-      | "composer"
-      | "performer"
-      | "track_no"
-      | "genre"
-      | "date"
-      | "comment"
-      | "any";
-    export type Query = { [key in QueryField]?: string[] };
-    export interface StrictEvents {
+
+    /**
+     * A tracklist track. Wraps a regular track and it's tracklist ID.
+     *
+     * The use of TlTrack allows the same track to appear multiple times in the
+     * tracklist.
+     *
+     * This class also accepts it's parameters as positional arguments. Both
+     * arguments must be provided, and they must appear in the order they are
+     * listed here.
+     *
+     * This class also supports iteration, so your extract its values like this:
+     *
+     *   `(tlid, track) = tl_track`
+     *
+     */
+    class TlTrack {
+      constructor({ tlid, track }: { tlid: number; track: Track });
+      readonly tlid: number;
+      readonly track: Track;
+    }
+    class Track {
+      constructor({
+        uri,
+        name,
+        artists,
+        album,
+        composers,
+        performers,
+        genre,
+        track_no,
+        disc_no,
+        date,
+        length,
+        bitrate,
+        comment,
+        musicbrainz_id,
+        last_modified,
+      }: {
+        /**
+         * The track URI
+         */
+        uri: URI;
+        /**
+         * The track name
+         */
+        name: string;
+        /**
+         * The track artists
+         */
+        artists: Artist[];
+        /**
+         * The track album
+         */
+        album: Album;
+        /**
+         * The track composers
+         */
+        composers: Artist[];
+        /**
+         * The track performers
+         */
+        performers: Artist[];
+        /**
+         * The track genre
+         */
+        genre: string;
+        /**
+         * The track number in the album
+         */
+        track_no?: number;
+        /**
+         * The disc number in the album
+         */
+        disc_no?: number;
+        /**
+         * The track release date (YYYY or YYYY-MM-DD)
+         */
+        date: string;
+        /**
+         * The track length in milliseconds
+         */
+        length?: number;
+        /**
+         * The track bitrate in kbit/s
+         */
+        bitrate: number;
+        /**
+         * The track comment
+         */
+        comment: string;
+        /**
+         * The track MusicBrainz ID
+         */
+        musicbrainz_id: string;
+        /**
+         * Integer representing when the track was last modified. Exact meaning
+         * depends on source of track. For local files this is the modification
+         * time in milliseconds since Unix epoch. For other backends it could be
+         * an equivalent timestamp or simply a version counter.
+         */
+        last_modified?: number;
+      });
       /**
-       * Client state
-       *
-       * You can get notified about when the Mopidy.js client is connected to the
-       * server and ready for method calls, when it's offline, and when it's
-       * trying to reconnect to the server by looking at the events
+       * The track URI
        */
-      "state:online": () => void;
-      "state:offline": () => void;
-      reconnectionPending: ({ timeToAttempt }: { timeToAttempt: number }) => void;
-      reconnecting: () => void;
+      readonly uri: URI;
       /**
-       * The client state events are also emitted under the aggregate event named
-       * state.
+       * The track name
        */
-      state: (args?: unknown) => void;
+      readonly name: string;
       /**
-       * Mopidy events
-       *
-       * You can get events sent from the Mopidy server by looking at the events
-       * with the name prefix 'event:'
+       * The track artists
        */
-      "event:muteChanged": ({ mute }: { mute: boolean }) => void;
+      readonly artists: Artist[];
+      /**
+       * The track album
+       */
+      readonly album: Album;
+      /**
+       * The track composers
+       */
+      readonly composers: Artist[];
+      /**
+       * The track performers
+       */
+      readonly performers: Artist[];
+      /**
+       * The track genre
+       */
+      readonly genre: string;
+      /**
+       * The track number in the album
+       */
+      readonly track_no: number;
+      /**
+       * The disc number in the album
+       */
+      readonly disc_no: number;
+      /**
+       * The track release date (YYYY or YYYY-MM-DD)
+       */
+      readonly date: string;
+      /**
+       * The track length in milliseconds.
+       */
+      readonly length: number;
+      /**
+       * The track bitrate in kbit/s
+       */
+      readonly bitrate: string;
+      /**
+       * The track comment
+       */
+      readonly comment: string;
+      /**
+       * The track MusicBrainz ID
+       */
+      readonly musicbrainz_id: string;
+      /**
+       * Integer representing when the track was last modified. Exact meaning
+       * depends on source of track. For local files this is the modification
+       * time in milliseconds since Unix epoch. For other backends it could be
+       * an equivalent timestamp or simply a version counter.
+       */
+      readonly last_modified: number;
+    }
+    class SearchResult {
+      constructor({
+        uri,
+        tracks,
+        artists,
+        albums,
+      }: {
+        /**
+         * The search result URI
+         */
+        uri: URI;
+        /**
+         * The tracks matching the search query
+         */
+        tracks: Track[];
+        /**
+         * The artists matching the search query
+         */
+        artists: Artist[];
+        /**
+         * The albums matching the search query
+         */
+        albums: Album[];
+      });
+      /**
+       * The search result URI
+       */
+      readonly uri: URI;
+      /**
+       * The tracks matching the search query
+       */
+      readonly tracks: Track[] | undefined;
+      /**
+       * The artists matching the search query
+       */
+      readonly artists: Artist[] | undefined;
+      /**
+       * The albums matching the search query
+       */
+      readonly albums: Album[] | undefined;
+    }
+
+    class Artist {
+      constructor({
+        uri,
+        name,
+        sortname,
+        musicbrainz_id,
+      }: {
+        /**
+         * The artist URI
+         */
+        uri: URI;
+        /**
+         * The artist name
+         */
+        name: string;
+        /**
+         * Artist name for better sorting, e.g. with articles stripped
+         */
+        sortname: string;
+        /**
+         * The MusicBrainz ID of the artist
+         */
+        musicbrainz_id: string;
+      });
+      /**
+       * The artist URI
+       */
+      readonly uri: URI;
+      /**
+       * The artist name
+       */
+      readonly name: string;
+      /**
+       * Artist name for better sorting, e.g. with articles stripped
+       */
+      readonly sortname: string;
+      /**
+       * The MusicBrainz ID of the artist
+       */
+      readonly musicbrainz_id: string;
+    }
+
+    class Album {
+      constructor({
+        uri,
+        name,
+        artists,
+        num_tracks,
+        num_discs,
+        date,
+        musicbrainz_id,
+      }: {
+        /**
+         * The album URI
+         */
+        uri: URI;
+        /**
+         * The album name
+         */
+        name: string;
+        /**
+         * A set of album artists
+         */
+        artists: Artist[];
+        /**
+         * The number of tracks in the album
+         */
+        num_tracks: number;
+        /**
+         * The number of discs in the album
+         */
+        num_discs: number;
+        /**
+         * The album release date (YYYY or YYYY-MM-DD)
+         */
+        date: string;
+        /**
+         * The MusicBrainz ID of the album
+         */
+        musicbrainz_id: string;
+      });
+      /**
+       * The album URI
+       */
+      readonly uri: URI;
+      /**
+       * The album name
+       */
+      readonly name: string;
+      /**
+       * A set of album artists
+       */
+      readonly artists: Artist[];
+      /**
+       * The number of tracks in the album
+       */
+      readonly num_tracks: number;
+      /**
+       * The number of discs in the album
+       */
+      readonly num_discs: number;
+      /**
+       * album release date (YYYY or YYYY-MM-DD)
+       */
+      readonly date: string;
+      /**
+       * The MusicBrainz ID of the album
+       */
+      readonly musicbrainz_id: string;
+    }
+
+    class Image {
+      constructor({
+        uri,
+        width,
+        height,
+      }: {
+        /**
+         * The URI of the image
+         */
+        uri: URI;
+        /**
+         * The width of the image
+         */
+        width?: number;
+        /**
+         * The height of the image
+         */
+        height?: number;
+      });
+      /**
+       * The URI of the image
+       */
+      readonly uri: URI;
+      /**
+       * The width of the image
+       */
+      readonly width: number;
+      /**
+       * The height of the image
+       */
+      readonly height: number;
+    }
+
+    class Playlist {
+      constructor({
+        uri,
+        name,
+        tracks,
+        last_modified
+      }: {
+        /**
+         * The URI of the image
+         */
+        uri: URI;
+        /**
+         * The playlist name
+         */
+        name: string;
+        /**
+         * The playlist’s tracks
+         */
+        tracks: Track[];
+        /**
+         * The playlist modification time in milliseconds since Unix epoch
+         */
+        last_modified: number
+      });
+      /**
+       * The URI of the image
+       */
+      readonly uri: URI;
+      /**
+       * The playlist name
+       */
+      readonly name: string;
+      /**
+       * The playlist’s tracks
+       */
+      readonly tracks: Track[];
+      /**
+       * The playlist modification time in milliseconds since Unix epoch
+       */
+      readonly last_modified: number;
+      /**
+       * The number of tracks in the playlist
+       */
+      readonly length: number;
+    }
+  }
+
+  /**
+   * The core API is the interface that is used by frontends like mopidy.http and Mopidy-MPD.
+   * The core layer is in between the frontends and the backends. Don’t forget that you will
+   * be accessing core as a Pykka actor. If you are only interested in being notified about
+   * changes in core see CoreListener.
+   */
+  namespace Core {
+    // ----------------- Events -----------------
+
+    /**
+     * Core events
+     *
+     * You can get events sent from the Mopidy server by looking at the events
+     * with the name prefix 'event:'
+     */
+    interface CoreListener {
+      /**
+       * Called whenever the mute state is changed.
+       */
+      "event:muteChanged": ({
+        mute
+      }: {
+        /**
+         * the new mute state
+         */
+        mute: boolean
+      }) => void;
       "event:optionsChanged": () => void;
       "event:playbackStateChanged": ({
         old_state,
@@ -99,7 +633,7 @@ declare module "mopidy" {
       "event:playlistChanged": ({
         playlist,
       }: {
-        playlist: Models.Playlist;
+        playlist: models.Playlist;
       }) => void;
       "event:playlistDeleted": ({
         /**
@@ -147,7 +681,7 @@ declare module "mopidy" {
          */
         timePosition,
       }: {
-        tl_track: Models.TlTrack;
+        tl_track: models.TlTrack;
         timePosition: number;
       }) => void;
       /**
@@ -163,7 +697,7 @@ declare module "mopidy" {
          */
         timePosition,
       }: {
-        tl_track: Models.TlTrack;
+        tl_track: models.TlTrack;
         timePosition: number;
       }) => void;
       /**
@@ -179,7 +713,7 @@ declare module "mopidy" {
          */
         timePosition,
       }: {
-        tl_track: Models.TlTrack;
+        tl_track: models.TlTrack;
         timePosition: number;
       }) => void;
       /**
@@ -191,7 +725,7 @@ declare module "mopidy" {
          */
         tl_track,
       }: {
-        tl_track: Models.TlTrack;
+        tl_track: models.TlTrack;
       }) => void;
       /**
        * Called whenever the tracklist is changed.
@@ -208,365 +742,316 @@ declare module "mopidy" {
       }: {
         volume: number;
       }) => void;
-      /**
-       * The events from Mopidy are also emitted under the aggregate event named
-       * event.
-       */
-      event: (args?: unknown) => void;
-      /**
-       * WebSocket events
-       *
-       * You can introspect what happens internally on the WebSocket by looking at
-       * the events.
-       *
-       * Of course, you can also do this using the web developer tools in any
-       * modern browser.
-       */
-      // @TODO Finish typing these, need to reverse engineer the listener type
-      websocket: any; // @TODO Is this valid?
-      "websocket:open": any;
-      "websocket:error": any;
-      "websocket:close": any;
-      "websocket:incomingMessage": any;
-      "websocket:outgoingMessage": any;
-    }
-    export interface CatchAllEvents {
-      event: ValueOf<StrictEvents>;
-    }
-    export type SubscribableString = keyof StrictEvents;
-
-    // https://docs.mopidy.com/en/latest/api/models/
-    export type ModelType =
-      | "album"
-      | "artist"
-      | "directory"
-      | "playlist"
-      | "track";
-    // @TODO rename to lowercase 'models'?
-    export namespace Models {
-      export class Ref<T extends ModelType> {
-        constructor({ uri, name, type }: { uri: URI; name: string; type: T });
-        static album(): Ref<"album">;
-        static artist(): Ref<"artist">;
-        static directory(): Ref<"directory">;
-        static playlist(): Ref<"playlist">;
-        static track(): Ref<"track">;
-        static ALBUM: "album";
-        static ARTIST: "artist";
-        static DIRECTORY: "directory";
-        static PLAYLIST: "playlist";
-        static TRACK: "track";
-        readonly name: string;
-        readonly type: T;
-        readonly uri: URI; // @TODO verify
-      }
-      /**
-       * A tracklist track. Wraps a regular track and itâ€™s tracklist ID.
-       *
-       * The use of TlTrack allows the same track to appear multiple times in the
-       * tracklist.
-       *
-       * This class also accepts itâ€™s parameters as positional arguments. Both
-       * arguments must be provided, and they must appear in the order they are
-       * listed here.
-       *
-       * This class also supports iteration, so your extract its values like this:
-       *
-       *   `(tlid, track) = tl_track`
-       *
-       */
-      export class TlTrack {
-        // @TODO Finish
-        constructor({ tlid, track }: { tlid: number; track: Track });
-        readonly tlid: number;
-        readonly track: Track;
-      }
-      export class Track {
-        constructor({
-          uri,
-          name,
-          artists,
-          album,
-          composers,
-          performers,
-          genre,
-          track_no,
-          disc_no,
-          date,
-          length,
-          bitrate,
-          comment,
-          musicbrainz_id,
-          last_modified,
-        }: {
-          uri: URI;
-          name: string;
-          artists: list;
-          album: Album;
-          composers: list;
-          performers: list;
-          genre: string;
-          track_no?: number;
-          disc_no?: number;
-          // track release date (YYYY or YYYY-MM-DD)
-          date: string;
-          // track length in milliseconds
-          length?: number;
-          // â€“ bitrate in kbit/s
-          bitrate: number;
-          comment: string;
-          musicbrainz_id: string;
-          /**
-           * Integer representing when the track was last modified. Exact meaning
-           * depends on source of track. For local files this is the modification
-           * time in milliseconds since Unix epoch. For other backends it could be
-           * an equivalent timestamp or simply a version counter.
-           */
-          last_modified?: number;
-        });
-        readonly album: string;
-        readonly artists: Artist[];
-        readonly bitrate: string;
-        readonly comment: ?string;
-        readonly composers: Artist[];
-        readonly performers: Artist[];
-        readonly date: string;
-        readonly disc_no: string; // @TODO Check if number
-        readonly name: string;
-        readonly genre: string;
-        /**
-         * Integer representing when the track was last modified. Exact meaning
-         * depends on source of track. For local files this is the modification
-         * time in milliseconds since Unix epoch. For other backends it could be
-         * an equivalent timestamp or simply a version counter.
-         */
-        readonly last_modified: number;
-        /**
-         * The track length in milliseconds.
-         */
-        readonly length: number;
-        readonly musicbrainz_id: string;
-        readonly track_no: string; // @TODO Check if number
-        readonly uri: Mopidy.URI;
-        /**
-         * Integer representing when the track was last modified. Exact meaning
-         * depends on source of track. For local files this is the modification
-         * time in milliseconds since Unix epoch. For other backends it could be
-         * an equivalent timestamp or simply a version counter.
-         */
-        readonly last_modified: ?number;
-        // The track length in milliseconds.
-        readonly length: ?string;
-        readonly musicbrainz_id: string;
-        readonly name: string;
-        readonly performers: string;
-        readonly track_no: ?string;
-        readonly uri: URI;
-      }
-      export class SearchResult {
-        constructor({
-          uri,
-          tracks,
-          artists,
-          albums,
-        }: {
-          uri: URI;
-          tracks: Track[];
-          artists: Artist[];
-          albums: Album[];
-        });
-        readonly uri: URI;
-        // These are documented as being part of the response, but in actuality
-        // they can come back incomplete. If there are only matching albums, you
-        // will only get an album property and the others will be undefined
-        // instead of an empty array.
-        readonly tracks: Track[] | undefined;
-        readonly artists: Artist[] | undefined;
-        readonly albums: Album[] | undefined;
-      }
-      // @TODO Finish
-      export class Artist {
-        construct({
-          uri, // artist URI
-          name, // artist name
-          sortname, // artist name for sorting
-          musicbrainz_id, // MusicBrainz ID
-        }: {
-          uri: URI;
-          name: string;
-          sortname: string;
-          musicbrainz_id: string;
-        });
-        readonly musicbrainz_id: string;
-        readonly name: string;
-        readonly sortname: string;
-        readonly uri: URI;
-      }
-      // @TODO Finish
-      export class Album {
-        constructor({
-          uri,
-          name,
-          artists,
-          num_tracks,
-          num_discs,
-          /**
-           * album release date (YYYY or YYYY-MM-DD)
-           */
-          date,
-          musicbrainz_id,
-        }: {
-          uri: URI;
-          name: string;
-          artists: Artist[];
-          num_tracks: number;
-          num_discs: number;
-          date: string;
-          musicbrainz_id: string;
-        });
-
-        readonly uri: URI;
-        readonly name: string;
-        readonly artists: Artist[];
-        readonly num_tracks: number;
-        readonly num_discs: number;
-        /**
-         * album release date (YYYY or YYYY-MM-DD)
-         */
-        readonly date: string;
-        readonly musicbrainz_id: string;
-      }
-      export class Image {
-        constructor({
-          uri,
-          width,
-          height,
-        }: {
-          uri: URI;
-          width?: number;
-          height?: number;
-        });
-        readonly height: ?number;
-        readonly width: ?number;
-        readonly uri: URI;
-      }
-      export class Playlist {
-        // @TODO Finish this
-      }
     }
 
     // ----------------- CONTROLLERS -----------------
+
     // https://docs.mopidy.com/en/latest/api/core/#tracklist-controller
-    export interface TracklistController {
+    interface TracklistController {
       /**
        * Add tracks to the tracklist.
        *
-       * If uris is given instead of tracks, the URIs are looked up in the library
+       * If `uris` is given instead of `tracks`, the URIs are looked up in the library
        * and the resulting tracks are added to the tracklist.
        *
-       * If at_position is given, the tracks are inserted at the given position in
-       * the tracklist. If at_position is not given, the tracks are appended to
+       * If `at_position` is given, the tracks are inserted at the given position in
+       * the tracklist. If `at_position` is not given, the tracks are appended to
        * the end of the tracklist.
        *
        * Triggers the `mopidy.core.CoreListener.tracklist_changed()` event.
        */
       add({
         tracks,
-        atPosition,
+        at_position,
         uris,
       }: {
-        tracks?: Models.Track[];
-        atPosition?: number;
+        /**
+         * The tracks to add
+         */
+        tracks?: models.Track[];
+        /**
+         * The position in tracklist to add tracks
+         */
+        at_position?: number;
+        /**
+         * list of URIs for tracks to add
+         */
         uris?: string[];
-      }): Promise<Models.TlTrack[]>;
-      // @TODO Finish
+      }): Promise<models.TlTrack[]>;
+
+      /**
+       * Remove the matching tracks from the tracklist.
+       * Uses `filter()` to lookup the tracks to remove.
+       *
+       * Triggers the `mopidy.core.CoreListener.tracklist_changed()` event.
+       */
+      remove({
+        criteria
+      }: {
+        /**
+         * (dict, of (string, list) pairs) – one or more rules to match by
+         */
+        criteria: { [key: string]: string[] }
+      }): Promise<models.TlTrack[]>;
+
+      /**
+       * Clear the tracklist
+       *
+       * Triggers the `mopidy.core.CoreListener.tracklist_changed()` event.
+       */
+      clear(): Promise<void>;
+
+      /**
+       * Move the tracks in the slice `[start:end]` to `to_position`.
+       *
+       * Triggers the `mopidy.core.CoreListener.tracklist_changed()` event.
+       */
+      move({
+        start,
+        end,
+        to_position
+      }: {
+        /**
+         * position of first track to move
+         */
+        start: number;
+        /**
+         * position after last track to move
+         */
+        end: number;
+        /**
+         * new position for the tracks
+         */
+        to_position: number;
+      }): Promise<void>
+
+      /**
+       * Shuffles the entire tracklist. If `start` and `end` is given
+       * only shuffles the slice `[start:end]`.
+       *
+       * Triggers the `mopidy.core.CoreListener.tracklist_changed()` event.
+       */
+      shuffle({
+        start,
+        end
+      }: {
+        /**
+         * position of first track to shuffle
+         */
+        start?: number;
+        /**
+         * position after last track to shuffle
+         */
+        end?: number;
+      }): Promise<void>
+
+      /**
+       * Get tracklist as list of `mopidy.models.TlTrack`
+       */
+      getTlTracks(): Promise<models.TlTrack[]>;
+
+      /**
+       * The position of the given track in the tracklist.
+       *
+       * If neither tl_track or tlid is given we return the index of the
+       * currently playing track.
+       */
       index({
         tl_track,
         tlid,
       }: {
-        tl_track?: Models.TlTrack;
-        tlid?: number; // @TODO alias for tlid?
-      }): number;
+        /**
+         * The track to find the index of
+         */
+        tl_track?: models.TlTrack;
+        /**
+         * TLID of the track to find the index of
+         */
+        tlid?: number;
+      }): Promise<number | null>;
 
       /**
-       * Get tracklist as a list of Track
+       * Get the tracklist version.
+       *
+       * Integer which is increased every time the tracklist is changed.
+       * Is not reset before Mopidy is restarted.
        */
-      getTracks(): Promise<Models.Track[]>;
+      getVersion(): Promise<number>;
+
+      /**
+       * Get length of the tracklist
+       */
+      getLength(): Promise<number>;
+
+      /**
+       * Get tracklist as list of `mopidy.models.Track`
+       */
+      getTracks(): Promise<models.Track[]>;
+
       /**
        * Returns a slice of the tracklist, limited by the given start and end
        * positions.
        */
       slice({
+        start,
+        end,
+      }: {
         /**
          * position of first track to include in slice
          */
-        start,
+        start: number;
         /**
          * position after last track to include in slice
          */
-        end,
-      }: {
-        start: number;
         end: number;
-      }): Promise<Models.TlTrack[]>;
+      }): Promise<models.TlTrack[]>;
+
+      /**
+       *
+       * Filter the tracklist by the given criteria.
+       *
+       * Each rule in the criteria consists of a model field and a list of values to compare it against. If * the model field matches any of the values, it may be returned.
+       *
+       * Only tracks that match all the given criteria are returned.
+       */
+      filter({
+        criteria
+      }: {
+        /**
+         * (dict, of (string, list) pairs) – one or more rules to match by
+         */
+        criteria: { [key: string]: string[] }
+      }): Promise<models.TlTrack[]>;
+
+      // ----------------- FUTURE STATE -----------------
+
+      /**
+       * The TLID of the track that will be played after the current track.
+       *
+       * Not necessarily the same TLID as returned by `get_next_tlid()`.
+       */
+      getEotTlid(): Promise<number | null>;
+
+      /**
+       * The tlid of the track that will be played if calling `mopidy.core.PlaybackController.next()`.
+       *
+       * For normal playback this is the next track in the tracklist. If repeat is enabled the next
+       * track can loop around the tracklist. When random is enabled this should be a random track,
+       * all tracks should be played once before the tracklist repeats.
+       */
+      getNextTlid(): Promise<number | null>;
+
+      /**
+       * Returns the TLID of the track that will be played if calling
+       * `mopidy.core.PlaybackController.previous()`.
+       *
+       * For normal playback this is the previous track in the tracklist. If random and/or
+       * consume is enabled it should return the current track instead.
+       */
+      getPreviousTlid(): Promise<number | null>;
+
+      /**
+       * The track that will be played after the given track.
+       *
+       * Not necessarily the same track as `next_track()`.
+       */
+      eotTrack({
+        tl_track
+      }: {
+        /**
+         * The reference track
+         */
+        tl_track?: models.TlTrack
+      }): Promise<models.TlTrack | null>;
+
+
+      // ----------------- DEPRECATED -----------------
+
+
+      /**
+       * @deprecated Deprecated since version 3.0: Use `get_next_tlid()` instead.
+       */
+      nextTrack({ tl_track }:{ tl_track: models.TlTrack }): Promise<models.TlTrack | null>;
+
+      /**
+       * @deprecated Deprecated since version 3.0: Use `get_previous_tlid()` instead.
+       */
+      previousTrack({ tl_track }:{ tl_track: models.TlTrack }): Promise<models.TlTrack | null>;
+
+
       // ----------------- OPTIONS -----------------
+
+      /**
+       * Get consume mode.
+       *
+       * True - Tracks are removed from the tracklist when they have been played.
+       * False - Tracks are not removed from the tracklist.
+       */
       getConsume(): Promise<boolean>;
+
       /**
        * Set consume mode.
        *
-       *   True = Tracks are removed from the tracklist when they have been
-       *   played.
-       *   False = Tracks are not removed from the tracklist.
+       * True - Tracks are removed from the tracklist when they have been played.
+       * False - Tracks are not removed from the tracklist.
        */
-      setConsume({ value }: { value: boolean }): void;
+      setConsume({ value }: { value: boolean }): Promise<void>;
+
+      /**
+       * Get random mode.
+       */
       getRandom(): Promise<boolean>;
+
       /**
        * Set random mode.
        *
-       *   True = Tracks are selected at random from the tracklist.
-       *   False = Tracks are played in the order of the tracklist.
+       * True - Tracks are selected at random from the tracklist.
+       * False - Tracks are played in the order of the tracklist.
        */
-      setRandom({ value }: { value: boolean }): void;
+      setRandom({ value }: { value: boolean }): Promise<void>;
+
+      /**
+       * Get repeat mode.
+       */
       getRepeat(): Promise<boolean>;
+
       /**
        * Set repeat mode.
        *
-       *   To repeat a single track, set both repeat and single.
+       * To repeat a single track, set both `repeat` and `single`.
        */
-      setRepeat({ value }: { value: boolean }): void;
+      setRepeat({ value }: { value: boolean }): Promise<void>;
+
+      /**
+       * Get single mode
+       */
       getSingle(): Promise<boolean>;
+
       /**
        * Set single mode.
        *
-       *   True = Playback is stopped after current song, unless in repeat mode.
-       *   False = Playback continues after current song.
+       * True - Playback is stopped after current song, unless in repeat mode.
+       * False - Playback continues after current song.
        */
-      setSingle({ value }: { value: boolean }): void;
+      setSingle({ value }: { value: boolean }): Promise<void>;
     }
-    export interface PlaybackController {
-      // @TODO Finish
 
-      // ----------------- PLAYBACK CONTROL -----------------
+    // https://docs.mopidy.com/en/latest/api/core/#playback-controller
+    interface PlaybackController {
       /**
-       * Play the given track, or if the given tl_track and tlid is None, play the
-       * currently active track.
+       * Play the given track, or if the given `tl_track` and `tlid` is None,
+       * play the currently active track.
        *
-       * Note that the track must already be in the tracklist.
-       *
-       * Deprecated since version 3.0: The tl_track argument. Use tlid instead.
-       *
-       * Parameters tl_track (mopidy.models.TlTrack or None) â€“ track to play
-       *
-       *   tlid (int or None) â€“ TLID of the track to play
-       *
+       * Note that the track *must* already be in the tracklist.
        */
       play({
         track,
         tlid,
       }: {
-        track?: Models.Track;
+        track?: models.TlTrack;
         tlid?: number;
       }): Promise<void>;
+
       /**
        * Change to the next track.
        *
@@ -574,6 +1059,7 @@ declare module "mopidy" {
        * continue. If it was paused, it will still be paused, etc.
        */
       next(): Promise<void>;
+
       /**
        * Change to the previous track.
        *
@@ -581,70 +1067,85 @@ declare module "mopidy" {
        * continue. If it was paused, it will still be paused, etc.
        */
       previous(): Promise<void>;
+
       /**
        * Stop playing.
        */
       stop(): Promise<void>;
+
       /**
        * Pause playback.
        */
       pause(): Promise<void>;
+
       /**
        * If paused, resume playing the current track.
        */
       resume(): Promise<void>;
+
       /**
        * Seeks to time position given in milliseconds.
-       *
-       *   Parameters
-       *     time_position (int) â€“ time position in milliseconds
-       *
-       *   Return type
-       *    True if successful, else False
        */
-      seek({ time_position }: { time_position: number }): Promise<boolean>;
+      seek({
+        time_position
+      }: {
+        /**
+         * time position in milliseconds
+         */
+        time_position: number
+      }): Promise<boolean>;
+
       // ----------------- CURRENT TRACK -----------------
+
       /**
        * Get the currently playing or selected track.
        */
-      getCurrentTlTrack(): Promise<Models.TlTrack | null>;
+      getCurrentTlTrack(): Promise<models.TlTrack | null>;
+
       /**
        * Get the currently playing or selected track.
        *
-       * Extracted from get_current_tl_track() for convenience.
+       * Extracted from `get_current_tl_track()` for convenience.
        */
-      getCurrentTrack(): Promise<Models.Track | null>;
+      getCurrentTrack(): Promise<models.Track | null>;
+
       /**
        * Get the current stream title or None.
        */
       getStreamTitle(): Promise<string | null>;
+
       /**
        * Get time position in milliseconds.
        */
       getTimePosition(): Promise<number | null>;
+
       // ----------------- PLAYBACK STATES -----------------
+
       /**
        * Get The playback state.
        */
       getState(): Promise<PlaybackState>;
+
       /**
-       * Set the playback state. See
-       * https://docs.mopidy.com/en/latest/api/core/#mopidy.core.PlaybackController.set_state
+       * Set the playback state. See:
+       *  https://docs.mopidy.com/en/latest/api/core/#mopidy.core.PlaybackController.set_state
        * for possible states and transitions
        */
       setState({ new_state }: { new_state: PlaybackState }): Promise<void>;
     }
-    export interface LibraryController {
+
+    // https://docs.mopidy.com/en/latest/api/core/#library-controller
+    interface LibraryController {
       /**
        * Browse directories and tracks at the given uri.
        *
        * uri is a string which represents some directory belonging to a backend.
        * To get the intial root directories for backends pass None as the URI.
        *
-       * @returns a list of mopidy.models.Ref objects for the directories and
+       * returns a list of `mopidy.models.Ref` objects for the directories and
        * tracks at the given uri.
        *
-       * The Ref objects representing tracks keep the trackâ€™s original URI. A
+       * The Ref objects representing tracks keep the track's original URI. A
        * matching pair of objects can look like this:
        *
        *    Track(uri='dummy:/foo.mp3', name='foo', artists=..., album=...)
@@ -656,13 +1157,20 @@ declare module "mopidy" {
        * this is checking the scheme, as it is used to route browse requests to
        * the correct backend.
        *
-       * For example, the dummy libraryâ€™s /bar directory could be returned like
+       * For example, the dummy library's /bar directory could be returned like
        * this:
        *
-       *    Ref.directory(uri='dummy:directory:/bar', name='bar')
-       *
+       *    `Ref.directory(uri='dummy:directory:/bar', name='bar')`
        */
-      browse({ uri }: { uri: URI }): Promise<Models.Ref[]>;
+      browse({
+        uri
+      }: {
+        /**
+         * URI to browse
+         */
+        uri: URI
+      }): Promise<models.Ref<any>[]>;
+
       /**
        * Search the library for tracks where `field` contains `values`.
        *
@@ -691,17 +1199,46 @@ declare module "mopidy" {
        *
        *     # Returns results matching artist 'xyz' and 'abc' in any backend
        *     search({'artist': ['xyz', 'abc']})
-       *
        */
       search({
         query,
         uris,
         exact,
       }: {
+        /**
+         * one or more queries to search for
+         */
         query: Query;
+        /**
+         * zero or more URI roots to limit the search to
+         */
         uris?: string[];
+        /**
+         * if the search should use exact matching
+         */
         exact?: boolean;
-      }): Promise<Models.SearchResult[]>;
+      }): Promise<models.SearchResult[]>;
+
+      /**
+       * Lookup the given URIs.
+       *
+       * If the URI expands to multiple tracks, the returned list will contain them all.
+       */
+      lookup({
+        uris
+      }:{
+        /**
+         * A list of URI's
+         */
+        uris: string[]
+      }): Promise<{ [index: string]: models.Track[] }>;
+
+      /**
+       *
+       * Refresh library. Limit to URI and below if an URI is given.
+       */
+      refresh({ uri }: { uri?: string }): Promise<void>
+
       /**
        * Lookup the images for the given URIs
        *
@@ -709,109 +1246,176 @@ declare module "mopidy" {
        * it tracks, albums, playlists. The lookup result is a dictionary mapping
        * the provided URIs to lists of images.
        *
-       * Unknown URIs or URIs the corresponding backend couldnâ€™t find anything for
+       * Unknown URIs or URIs the corresponding backend couldn't find anything for
        * will simply return an empty list for that URI.
-       *
-       * @returns {uri: tuple of mopidy.models.Image}
-       *
        */
       getImages({
+        uris
+      }:{
         /**
-         * list of URIs to find images for
+         * A list of URI's
          */
-        uris,
-      }: {
-        uris: string[];
-      }): Promise<{ [index: string]: Models.Image[] }>;
+        uris: string[]
+      }): Promise<{ [index: string]: models.Image[] }>;
     }
-    export interface PlaylistsController {}
-    export interface MixerController {}
-    export interface HistoryController {}
-    export interface Core {
-      PlaybackState: IPlaybackState;
-    }
-    class Mopidy {
-      // ----------------- MOPIDY.JS-SPECIFIC API -----------------
 
+    // https://docs.mopidy.com/en/latest/api/core/#playlists-controller
+    interface PlaylistsController {
       /**
-       * Mopidy.js is a JavaScript library for controlling a Mopidy music server.
-       *
-       * The library makes Mopidy's core API available from browsers and Node.js
-       * programs, using JSON-RPC over a WebSocket to communicate with Mopidy.
-       *
-       * This library is the foundation of most Mopidy web clients.
-       */
-      constructor(options: Options);
-      /**
-       * Explicit connect function for when autoConnect:false is passed to
-       * constructor.
-       */
-      connect(): Promise<void>;
-      /**
-       * Close the WebSocket without reconnecting. Letting the object be garbage
-       * collected will have the same effect, so this isn't strictly necessary.
-       */
-      close(): Promise<void>;
-
-      // ----------------- EVENT SUBSCRIPTION -----------------
-      on<
-        TEvent extends keyof StrictEvents,
-        TListener extends StrictEvents[TEvent]
-      >(event: TEvent, listener: TListener): void;
-
-      off(): void;
-      off<
-        TEvent extends keyof StrictEvents,
-        TListener extends StrictEvents[TEvent]
-      >(event: TEvent, listener?: TListener): void;
-
-      // ----------------- CORE API -----------------
-      // https://docs.mopidy.com/en/latest/api/core/#module-mopidy.core
-      core: Core;
-      /**
-       * Manages everything related to the list of tracks we will play. See
-       * TracklistController. Undefined before Mopidy connects.
-       */
-      tracklist: TracklistController | undefined;
-      /**
-       * Manages playback state and the current playing track. See
-       * PlaybackController. Undefined before Mopidy connects.
-       */
-      playback: PlaybackController | undefined;
-      /**
-       * Manages the music library, e.g. searching and browsing for music. See
-       * LibraryController. Undefined before Mopidy connects.
-       */
-      library: LibraryController | undefined;
-      /**
-       * Manages stored playlists. See PlaylistsController. Undefined before
-       * Mopidy connects.
-       */
-      playlists: PlaylistsController | undefined;
-      /**
-       * Manages volume and muting. See MixerController. Undefined before Mopidy
-       * connects.
-       */
-      mixer: MixerController | undefined;
-      /**
-       * Keeps record of what tracks have been played. See HistoryController.
-       * Undefined before Mopidy connects.
-       */
-      history: HistoryController | undefined;
-
-      // @TODO
-      // CoreListener
-      // Core
-
-      /**
-       * Get list of URI schemes we can handle
+       * Get the list of URI schemes that support playlists.
        */
       getUriSchemes(): Promise<string[]>;
+
+      // ----------------- FETCHING -----------------
+
       /**
-       * Get version of the Mopidy core API
+       * Get a list of the currently available playlists.
+       *
+       * Returns a list of Ref objects referring to the playlists. In other words,
+       * no information about the playlists’ content is given.
        */
-      getVersion(): Promise<string>;
+      asList(): Promise<models.Ref<any>[]>;
+
+      /**
+       * Get the items in a playlist specified by `uri`.
+       *
+       * Returns a list of Ref objects referring to the playlist’s items.
+       *
+       * If a playlist with the given uri doesn’t exist, it returns `None`.
+       */
+      getItems({ uri }: { uri: string }): Promise<models.Ref<any>[] | null>;
+
+      /**
+       * Lookup playlist with given URI in both the set of playlists and in any other
+       * playlist sources. Returns `None` if not found.
+       */
+      lookup({ uri }: { uri: URI }): Promise<models.Playlist | null>;
+
+      /**
+       * Refresh the playlists in playlists.
+       *
+       * If uri_scheme is None, all backends are asked to refresh. If `uri_scheme` is an URI scheme
+       * handled by a backend, only that backend is asked to refresh. If `uri_scheme` doesn’t
+       * match any current backend, nothing happens.
+       */
+      refresh({ uri_scheme }: { uri_scheme?: string }): Promise<void>;
+
+      // ----------------- MANIPULATING -----------------
+
+      /**
+       * Create a new playlist.
+       *
+       * If uri_scheme matches an URI scheme handled by a current backend, that backend is
+       * asked to create the playlist. If `uri_scheme` is None or doesn’t match a current backend,
+       * the first backend is asked to create the playlist.
+       *
+       * All new playlists must be created by calling this method, and not by creating new
+       * instances of mopidy.models.Playlist.
+       */
+      create({
+        name,
+        uri_scheme
+      }: {
+        /**
+         * name of the new playlist
+         */
+        name: string;
+        /**
+         * use the backend matching the URI scheme
+         */
+        uri_scheme?: string;
+      }): Promise<models.Playlist | null>;
+
+      /**
+       * Save the playlist.
+       *
+       * For a playlist to be saveable, it must have the uri attribute set. You must not set
+       * the uri atribute yourself, but use playlist objects returned by create() or
+       * retrieved from playlists, which will always give you saveable playlists.
+       *
+       * The method returns the saved playlist. The return playlist may differ from the saved
+       * playlist. E.g. if the playlist name was changed, the returned playlist may have a
+       * different URI. The caller of this method must throw away the playlist sent to
+       * this method, and use the returned playlist instead.
+       *
+       * If the playlist’s URI isn’t set or doesn’t match the URI scheme of a current backend,
+       * nothing is done and None is returned.
+       */
+      save({
+        playlist
+      }: {
+        /**
+         * The playlist
+         */
+        playlist: models.Playlist
+      }): Promise<models.Playlist | null>;
+
+      /**
+       * Delete playlist identified by the URI.
+       *
+       * If the URI doesn’t match the URI schemes handled by the current backends, nothing happens.
+       *
+       * Returns True if deleted, False otherwise.
+       */
+      delete({
+        uri
+      }: {
+        /**
+         * URI of the playlist to delete
+         */
+        uri: URI
+      }): Promise<boolean>;
     }
 
-    export = Mopidy;
+    // https://docs.mopidy.com/en/latest/api/core/#mixer-controller
+    interface MixerController {
+      /**
+       * Get mute state.
+       *
+       * True if muted, False unmuted, None if unknown.
+       */
+      getMute(): Promise<boolean | null>;
+
+      /**
+       * Set mute state.
+       *
+       * True to mute, False to unmute.
+       *
+       * Returns True if call is successful, otherwise False.
+       */
+      setMute({ mute }: { mute: boolean }): Promise<boolean>;
+
+      /**
+       * Get the volume.
+       *
+       * Integer in range [0..100] or None if unknown.
+       *
+       * The volume scale is linear.
+       */
+      getVolume(): Promise<number | null>;
+
+      /**
+       * Set the volume.
+       *
+       * The volume is defined as an integer in range [0..100].
+       *
+       * The volume scale is linear.
+       */
+      setVolume({ volume }: { volume: number }): Promise<boolean>;
+    }
+
+    interface HistoryController {
+      /**
+       * Get the track history.
+       *
+       * The timestamps are milliseconds since epoch.
+       */
+      getHistory(): Promise<{ [index: string]: models.Ref<any>[] }>;
+
+      /**
+       * Get the number of tracks in the history.
+       */
+      getLength(): Promise<number>;
+    }
   }
+}

--- a/src/mopidy.d.ts
+++ b/src/mopidy.d.ts
@@ -390,15 +390,15 @@ declare namespace Mopidy {
       /**
        * The tracks matching the search query
        */
-      readonly tracks: Track[] | undefined;
+      readonly tracks: Track[];
       /**
        * The artists matching the search query
        */
-      readonly artists: Artist[] | undefined;
+      readonly artists: Artist[];
       /**
        * The albums matching the search query
        */
-      readonly albums: Album[] | undefined;
+      readonly albums: Album[];
     }
 
     class Artist {

--- a/src/mopidy.d.ts
+++ b/src/mopidy.d.ts
@@ -44,32 +44,32 @@ declare class Mopidy {
    * Manages everything related to the list of tracks we will play. See
    * TracklistController. Undefined before Mopidy connects.
    */
-  tracklist: Mopidy.Core.TracklistController | undefined;
+  tracklist?: Mopidy.Core.TracklistController;
   /**
    * Manages playback state and the current playing track. See
    * PlaybackController. Undefined before Mopidy connects.
    */
-  playback: Mopidy.Core.PlaybackController | undefined;
+  playback?: Mopidy.Core.PlaybackController;
   /**
    * Manages the music library, e.g. searching and browsing for music. See
    * LibraryController. Undefined before Mopidy connects.
    */
-  library: Mopidy.Core.LibraryController | undefined;
+  library?: Mopidy.Core.LibraryController;
   /**
    * Manages stored playlists. See PlaylistsController. Undefined before
    * Mopidy connects.
    */
-  playlists: Mopidy.Core.PlaylistsController | undefined;
+  playlists?: Mopidy.Core.PlaylistsController;
   /**
    * Manages volume and muting. See MixerController. Undefined before Mopidy
    * connects.
    */
-  mixer: Mopidy.Core.MixerController | undefined;
+  mixer?: Mopidy.Core.MixerController;
   /**
    * Keeps record of what tracks have been played. See HistoryController.
    * Undefined before Mopidy connects.
    */
-  history: Mopidy.Core.HistoryController | undefined;
+  history?: Mopidy.Core.HistoryController;
 
   /**
    * Get list of URI schemes we can handle

--- a/src/mopidy.d.ts
+++ b/src/mopidy.d.ts
@@ -1,9 +1,9 @@
 // Type definitions for Mopidy.js v1.1.0, Mopidy v3.0.2 WebSocket API
 
-export = Mopidy
+export = Mopidy;
 
 declare class Mopidy {
-  // ----------------- MOPIDY.JS-SPECIFIC API -----------------
+  // ----------------- MOPIDY.JS SPECIFIC API -----------------
 
   /**
    * Mopidy.js is a JavaScript library for controlling a Mopidy music server.
@@ -28,13 +28,15 @@ declare class Mopidy {
   // ----------------- EVENT SUBSCRIPTION -----------------
 
   on<K extends keyof Mopidy.StrictEvents>(
-    name: K, listener: Mopidy.StrictEvents[K]
+    name: K,
+    listener: Mopidy.StrictEvents[K]
   ): this;
 
   off(): void;
   off<K extends keyof Mopidy.StrictEvents>(
-    name: K, listener: Mopidy.StrictEvents[K]
- ): this;
+    name: K,
+    listener: Mopidy.StrictEvents[K]
+  ): this;
 
   // ----------------- CORE API -----------------
 
@@ -172,12 +174,7 @@ declare namespace Mopidy {
   }
 
   // https://docs.mopidy.com/en/latest/api/models/
-  type ModelType =
-    | "album"
-    | "artist"
-    | "directory"
-    | "playlist"
-    | "track";
+  type ModelType = "album" | "artist" | "directory" | "playlist" | "track";
   namespace models {
     class Ref<T extends ModelType> {
       constructor({ uri, name, type }: { uri: URI; name: string; type: T });
@@ -553,7 +550,7 @@ declare namespace Mopidy {
         uri,
         name,
         tracks,
-        last_modified
+        last_modified,
       }: {
         /**
          * The URI of the image
@@ -570,7 +567,7 @@ declare namespace Mopidy {
         /**
          * The playlist modification time in milliseconds since Unix epoch
          */
-        last_modified: number
+        last_modified: number;
       });
       /**
        * The URI of the image
@@ -615,12 +612,12 @@ declare namespace Mopidy {
        * Called whenever the mute state is changed.
        */
       "event:muteChanged": ({
-        mute
+        mute,
       }: {
         /**
          * the new mute state
          */
-        mute: boolean
+        mute: boolean;
       }) => void;
       "event:optionsChanged": () => void;
       "event:playbackStateChanged": ({
@@ -786,12 +783,12 @@ declare namespace Mopidy {
        * Triggers the `mopidy.core.CoreListener.tracklist_changed()` event.
        */
       remove({
-        criteria
+        criteria,
       }: {
         /**
          * (dict, of (string, list) pairs) – one or more rules to match by
          */
-        criteria: { [key: string]: string[] }
+        criteria: { [key: string]: string[] };
       }): Promise<models.TlTrack[]>;
 
       /**
@@ -809,7 +806,7 @@ declare namespace Mopidy {
       move({
         start,
         end,
-        to_position
+        to_position,
       }: {
         /**
          * position of first track to move
@@ -823,7 +820,7 @@ declare namespace Mopidy {
          * new position for the tracks
          */
         to_position: number;
-      }): Promise<void>
+      }): Promise<void>;
 
       /**
        * Shuffles the entire tracklist. If `start` and `end` is given
@@ -833,7 +830,7 @@ declare namespace Mopidy {
        */
       shuffle({
         start,
-        end
+        end,
       }: {
         /**
          * position of first track to shuffle
@@ -843,7 +840,7 @@ declare namespace Mopidy {
          * position after last track to shuffle
          */
         end?: number;
-      }): Promise<void>
+      }): Promise<void>;
 
       /**
        * Get tracklist as list of `mopidy.models.TlTrack`
@@ -915,12 +912,12 @@ declare namespace Mopidy {
        * Only tracks that match all the given criteria are returned.
        */
       filter({
-        criteria
+        criteria,
       }: {
         /**
          * (dict, of (string, list) pairs) – one or more rules to match by
          */
-        criteria: { [key: string]: string[] }
+        criteria: { [key: string]: string[] };
       }): Promise<models.TlTrack[]>;
 
       // ----------------- FUTURE STATE -----------------
@@ -956,28 +953,33 @@ declare namespace Mopidy {
        * Not necessarily the same track as `next_track()`.
        */
       eotTrack({
-        tl_track
+        tl_track,
       }: {
         /**
          * The reference track
          */
-        tl_track?: models.TlTrack
+        tl_track?: models.TlTrack;
       }): Promise<models.TlTrack | null>;
 
-
       // ----------------- DEPRECATED -----------------
-
 
       /**
        * @deprecated Deprecated since version 3.0: Use `get_next_tlid()` instead.
        */
-      nextTrack({ tl_track }:{ tl_track: models.TlTrack }): Promise<models.TlTrack | null>;
+      nextTrack({
+        tl_track,
+      }: {
+        tl_track: models.TlTrack;
+      }): Promise<models.TlTrack | null>;
 
       /**
        * @deprecated Deprecated since version 3.0: Use `get_previous_tlid()` instead.
        */
-      previousTrack({ tl_track }:{ tl_track: models.TlTrack }): Promise<models.TlTrack | null>;
-
+      previousTrack({
+        tl_track,
+      }: {
+        tl_track: models.TlTrack;
+      }): Promise<models.TlTrack | null>;
 
       // ----------------- OPTIONS -----------------
 
@@ -1087,12 +1089,12 @@ declare namespace Mopidy {
        * Seeks to time position given in milliseconds.
        */
       seek({
-        time_position
+        time_position,
       }: {
         /**
          * time position in milliseconds
          */
-        time_position: number
+        time_position: number;
       }): Promise<boolean>;
 
       // ----------------- CURRENT TRACK -----------------
@@ -1163,12 +1165,12 @@ declare namespace Mopidy {
        *    `Ref.directory(uri='dummy:directory:/bar', name='bar')`
        */
       browse({
-        uri
+        uri,
       }: {
         /**
          * URI to browse
          */
-        uri: URI
+        uri: URI;
       }): Promise<models.Ref<any>[]>;
 
       /**
@@ -1225,19 +1227,19 @@ declare namespace Mopidy {
        * If the URI expands to multiple tracks, the returned list will contain them all.
        */
       lookup({
-        uris
-      }:{
+        uris,
+      }: {
         /**
          * A list of URI's
          */
-        uris: string[]
+        uris: string[];
       }): Promise<{ [index: string]: models.Track[] }>;
 
       /**
        *
        * Refresh library. Limit to URI and below if an URI is given.
        */
-      refresh({ uri }: { uri?: string }): Promise<void>
+      refresh({ uri }: { uri?: string }): Promise<void>;
 
       /**
        * Lookup the images for the given URIs
@@ -1250,12 +1252,12 @@ declare namespace Mopidy {
        * will simply return an empty list for that URI.
        */
       getImages({
-        uris
-      }:{
+        uris,
+      }: {
         /**
          * A list of URI's
          */
-        uris: string[]
+        uris: string[];
       }): Promise<{ [index: string]: models.Image[] }>;
     }
 
@@ -1314,7 +1316,7 @@ declare namespace Mopidy {
        */
       create({
         name,
-        uri_scheme
+        uri_scheme,
       }: {
         /**
          * name of the new playlist
@@ -1342,12 +1344,12 @@ declare namespace Mopidy {
        * nothing is done and None is returned.
        */
       save({
-        playlist
+        playlist,
       }: {
         /**
          * The playlist
          */
-        playlist: models.Playlist
+        playlist: models.Playlist;
       }): Promise<models.Playlist | null>;
 
       /**
@@ -1358,12 +1360,12 @@ declare namespace Mopidy {
        * Returns True if deleted, False otherwise.
        */
       delete({
-        uri
+        uri,
       }: {
         /**
          * URI of the playlist to delete
          */
-        uri: URI
+        uri: URI;
       }): Promise<boolean>;
     }
 

--- a/src/mopidy.d.ts
+++ b/src/mopidy.d.ts
@@ -1,0 +1,817 @@
+// Type definitions for Mopidy.js v1.0.1, Mopidy v3.0.1 WebSocket API
+
+declare module "mopidy" {
+    type ValueOf<T> = T[keyof T];
+
+    export interface Options {
+      /**
+       * URL used when creating new WebSocket objects.
+       *
+       * In a browser environment, it defaults to
+       * ws://${document.location.host}/mopidy/ws. If the current page is served
+       * over HTTPS, it defaults to using wss:// instead of ws://.
+       *
+       * In a non-browser environment, where document.location isn't available, it
+       * defaults to ws://localhost/mopidy/ws.
+       */
+      webSocketUrl: string;
+      /**
+       * Whether or not to connect to the WebSocket on instance creation. Defaults
+       * to true.
+       */
+      autoConnect?: boolean;
+      /**
+       * The minimum number of milliseconds to wait after a connection error before
+       * we try to reconnect. For every failed attempt, the backoff delay is doubled
+       * until it reaches backoffDelayMax. Defaults to 1000.
+       */
+      backoffDelayMin?: number;
+      /**
+       * The maximum number of milliseconds to wait after a connection error before
+       * we try to reconnect. Defaults to 64000.
+       */
+      backoffDelayMax?: number;
+      /**
+       * If set, this object will be used to log errors from Mopidy.js. This is
+       * mostly useful for testing Mopidy.js. Defaults to console.
+       */
+      console?: Object;
+      /**
+       * An existing WebSocket object to be used instead of creating a new
+       * WebSocket. Defaults to undefined.
+       */
+      webSocket?: WebSocket;
+      /**
+       * Controls whether the JSON-RPC API is passed arguments as arrays or named
+       * objects. The only verison that is supported by this typing file is named
+       * objects.
+       */
+      callingConvention?: "by-name-only";
+    }
+    export type URI = string;
+    export type PlaybackState = "playing" | "paused" | "stopped";
+    export type QueryField =
+      | "uri"
+      | "track_name"
+      | "album"
+      | "artist"
+      | "albumartist"
+      | "composer"
+      | "performer"
+      | "track_no"
+      | "genre"
+      | "date"
+      | "comment"
+      | "any";
+    export type Query = { [key in QueryField]?: string[] };
+    export interface StrictEvents {
+      /**
+       * Client state
+       *
+       * You can get notified about when the Mopidy.js client is connected to the
+       * server and ready for method calls, when it's offline, and when it's
+       * trying to reconnect to the server by looking at the events
+       */
+      "state:online": () => void;
+      "state:offline": () => void;
+      reconnectionPending: ({ timeToAttempt }: { timeToAttempt: number }) => void;
+      reconnecting: () => void;
+      /**
+       * The client state events are also emitted under the aggregate event named
+       * state.
+       */
+      state: (args?: unknown) => void;
+      /**
+       * Mopidy events
+       *
+       * You can get events sent from the Mopidy server by looking at the events
+       * with the name prefix 'event:'
+       */
+      "event:muteChanged": ({ mute }: { mute: boolean }) => void;
+      "event:optionsChanged": () => void;
+      "event:playbackStateChanged": ({
+        old_state,
+        new_state,
+      }: {
+        old_state: PlaybackState;
+        new_state: PlaybackState;
+      }) => void;
+      "event:playlistChanged": ({
+        playlist,
+      }: {
+        playlist: Models.Playlist;
+      }) => void;
+      "event:playlistDeleted": ({
+        /**
+         * the URI of the deleted playlist
+         */
+        uri,
+      }: {
+        uri: URI;
+      }) => void;
+      "event:playlistsLoaded": () => void;
+      /**
+       * Called whenever the time position changes by an unexpected amount, e.g.
+       * at seek to a new time position.
+       */
+      "event:seeked": ({
+        /**
+         * the position that was seeked to in milliseconds
+         */
+        time_position,
+      }: {
+        time_position: number;
+      }) => void;
+      /**
+       * Called whenever the currently playing stream title changes.
+       */
+      "event:streamTitleChanged": ({
+        /**
+         * the new stream title
+         */
+        title,
+      }: {
+        title: string;
+      }) => void;
+
+      /**
+       * Called whenever playback of a track ends.
+       */
+      "event:trackPlaybackEnded": ({
+        /**
+         * the track that was played before playback stopped
+         */
+        tl_track,
+        /**
+         * the time position in milliseconds
+         */
+        timePosition,
+      }: {
+        tl_track: Models.TlTrack;
+        timePosition: number;
+      }) => void;
+      /**
+       * Called whenever track playback is paused.
+       */
+      "event:trackPlaybackPaused": ({
+        /**
+         * the track that was playing when playback paused
+         */
+        tl_track,
+        /**
+         * the time position in milliseconds
+         */
+        timePosition,
+      }: {
+        tl_track: Models.TlTrack;
+        timePosition: number;
+      }) => void;
+      /**
+       * Called whenever track playback is resumed.
+       */
+      "event:trackPlaybackResumed": ({
+        /**
+         * the track that was playing when playback resumed
+         */
+        tl_track,
+        /**
+         * the time position in milliseconds
+         */
+        timePosition,
+      }: {
+        tl_track: Models.TlTrack;
+        timePosition: number;
+      }) => void;
+      /**
+       * Called whenever a new track starts playing.
+       */
+      "event:trackPlaybackStarted": ({
+        /**
+         * the track that just started playing
+         */
+        tl_track,
+      }: {
+        tl_track: Models.TlTrack;
+      }) => void;
+      /**
+       * Called whenever the tracklist is changed.
+       */
+      "event:tracklistChanged": () => void;
+      /**
+       * Called whenever the volume is changed.
+       */
+      "event:volumeChanged": ({
+        /**
+         * the new volume in the range [0..100]
+         */
+        volume,
+      }: {
+        volume: number;
+      }) => void;
+      /**
+       * The events from Mopidy are also emitted under the aggregate event named
+       * event.
+       */
+      event: (args?: unknown) => void;
+      /**
+       * WebSocket events
+       *
+       * You can introspect what happens internally on the WebSocket by looking at
+       * the events.
+       *
+       * Of course, you can also do this using the web developer tools in any
+       * modern browser.
+       */
+      // @TODO Finish typing these, need to reverse engineer the listener type
+      websocket: any; // @TODO Is this valid?
+      "websocket:open": any;
+      "websocket:error": any;
+      "websocket:close": any;
+      "websocket:incomingMessage": any;
+      "websocket:outgoingMessage": any;
+    }
+    export interface CatchAllEvents {
+      event: ValueOf<StrictEvents>;
+    }
+    export type SubscribableString = keyof StrictEvents;
+
+    // https://docs.mopidy.com/en/latest/api/models/
+    export type ModelType =
+      | "album"
+      | "artist"
+      | "directory"
+      | "playlist"
+      | "track";
+    // @TODO rename to lowercase 'models'?
+    export namespace Models {
+      export class Ref<T extends ModelType> {
+        constructor({ uri, name, type }: { uri: URI; name: string; type: T });
+        static album(): Ref<"album">;
+        static artist(): Ref<"artist">;
+        static directory(): Ref<"directory">;
+        static playlist(): Ref<"playlist">;
+        static track(): Ref<"track">;
+        static ALBUM: "album";
+        static ARTIST: "artist";
+        static DIRECTORY: "directory";
+        static PLAYLIST: "playlist";
+        static TRACK: "track";
+        readonly name: string;
+        readonly type: T;
+        readonly uri: URI; // @TODO verify
+      }
+      /**
+       * A tracklist track. Wraps a regular track and itâ€™s tracklist ID.
+       *
+       * The use of TlTrack allows the same track to appear multiple times in the
+       * tracklist.
+       *
+       * This class also accepts itâ€™s parameters as positional arguments. Both
+       * arguments must be provided, and they must appear in the order they are
+       * listed here.
+       *
+       * This class also supports iteration, so your extract its values like this:
+       *
+       *   `(tlid, track) = tl_track`
+       *
+       */
+      export class TlTrack {
+        // @TODO Finish
+        constructor({ tlid, track }: { tlid: number; track: Track });
+        readonly tlid: number;
+        readonly track: Track;
+      }
+      export class Track {
+        constructor({
+          uri,
+          name,
+          artists,
+          album,
+          composers,
+          performers,
+          genre,
+          track_no,
+          disc_no,
+          date,
+          length,
+          bitrate,
+          comment,
+          musicbrainz_id,
+          last_modified,
+        }: {
+          uri: URI;
+          name: string;
+          artists: list;
+          album: Album;
+          composers: list;
+          performers: list;
+          genre: string;
+          track_no?: number;
+          disc_no?: number;
+          // track release date (YYYY or YYYY-MM-DD)
+          date: string;
+          // track length in milliseconds
+          length?: number;
+          // â€“ bitrate in kbit/s
+          bitrate: number;
+          comment: string;
+          musicbrainz_id: string;
+          /**
+           * Integer representing when the track was last modified. Exact meaning
+           * depends on source of track. For local files this is the modification
+           * time in milliseconds since Unix epoch. For other backends it could be
+           * an equivalent timestamp or simply a version counter.
+           */
+          last_modified?: number;
+        });
+        readonly album: string;
+        readonly artists: Artist[];
+        readonly bitrate: string;
+        readonly comment: ?string;
+        readonly composers: Artist[];
+        readonly performers: Artist[];
+        readonly date: string;
+        readonly disc_no: string; // @TODO Check if number
+        readonly name: string;
+        readonly genre: string;
+        /**
+         * Integer representing when the track was last modified. Exact meaning
+         * depends on source of track. For local files this is the modification
+         * time in milliseconds since Unix epoch. For other backends it could be
+         * an equivalent timestamp or simply a version counter.
+         */
+        readonly last_modified: number;
+        /**
+         * The track length in milliseconds.
+         */
+        readonly length: number;
+        readonly musicbrainz_id: string;
+        readonly track_no: string; // @TODO Check if number
+        readonly uri: Mopidy.URI;
+        /**
+         * Integer representing when the track was last modified. Exact meaning
+         * depends on source of track. For local files this is the modification
+         * time in milliseconds since Unix epoch. For other backends it could be
+         * an equivalent timestamp or simply a version counter.
+         */
+        readonly last_modified: ?number;
+        // The track length in milliseconds.
+        readonly length: ?string;
+        readonly musicbrainz_id: string;
+        readonly name: string;
+        readonly performers: string;
+        readonly track_no: ?string;
+        readonly uri: URI;
+      }
+      export class SearchResult {
+        constructor({
+          uri,
+          tracks,
+          artists,
+          albums,
+        }: {
+          uri: URI;
+          tracks: Track[];
+          artists: Artist[];
+          albums: Album[];
+        });
+        readonly uri: URI;
+        // These are documented as being part of the response, but in actuality
+        // they can come back incomplete. If there are only matching albums, you
+        // will only get an album property and the others will be undefined
+        // instead of an empty array.
+        readonly tracks: Track[] | undefined;
+        readonly artists: Artist[] | undefined;
+        readonly albums: Album[] | undefined;
+      }
+      // @TODO Finish
+      export class Artist {
+        construct({
+          uri, // artist URI
+          name, // artist name
+          sortname, // artist name for sorting
+          musicbrainz_id, // MusicBrainz ID
+        }: {
+          uri: URI;
+          name: string;
+          sortname: string;
+          musicbrainz_id: string;
+        });
+        readonly musicbrainz_id: string;
+        readonly name: string;
+        readonly sortname: string;
+        readonly uri: URI;
+      }
+      // @TODO Finish
+      export class Album {
+        constructor({
+          uri,
+          name,
+          artists,
+          num_tracks,
+          num_discs,
+          /**
+           * album release date (YYYY or YYYY-MM-DD)
+           */
+          date,
+          musicbrainz_id,
+        }: {
+          uri: URI;
+          name: string;
+          artists: Artist[];
+          num_tracks: number;
+          num_discs: number;
+          date: string;
+          musicbrainz_id: string;
+        });
+
+        readonly uri: URI;
+        readonly name: string;
+        readonly artists: Artist[];
+        readonly num_tracks: number;
+        readonly num_discs: number;
+        /**
+         * album release date (YYYY or YYYY-MM-DD)
+         */
+        readonly date: string;
+        readonly musicbrainz_id: string;
+      }
+      export class Image {
+        constructor({
+          uri,
+          width,
+          height,
+        }: {
+          uri: URI;
+          width?: number;
+          height?: number;
+        });
+        readonly height: ?number;
+        readonly width: ?number;
+        readonly uri: URI;
+      }
+      export class Playlist {
+        // @TODO Finish this
+      }
+    }
+
+    // ----------------- CONTROLLERS -----------------
+    // https://docs.mopidy.com/en/latest/api/core/#tracklist-controller
+    export interface TracklistController {
+      /**
+       * Add tracks to the tracklist.
+       *
+       * If uris is given instead of tracks, the URIs are looked up in the library
+       * and the resulting tracks are added to the tracklist.
+       *
+       * If at_position is given, the tracks are inserted at the given position in
+       * the tracklist. If at_position is not given, the tracks are appended to
+       * the end of the tracklist.
+       *
+       * Triggers the `mopidy.core.CoreListener.tracklist_changed()` event.
+       */
+      add({
+        tracks,
+        atPosition,
+        uris,
+      }: {
+        tracks?: Models.Track[];
+        atPosition?: number;
+        uris?: string[];
+      }): Promise<Models.TlTrack[]>;
+      // @TODO Finish
+      index({
+        tl_track,
+        tlid,
+      }: {
+        tl_track?: Models.TlTrack;
+        tlid?: number; // @TODO alias for tlid?
+      }): number;
+
+      /**
+       * Get tracklist as a list of Track
+       */
+      getTracks(): Promise<Models.Track[]>;
+      /**
+       * Returns a slice of the tracklist, limited by the given start and end
+       * positions.
+       */
+      slice({
+        /**
+         * position of first track to include in slice
+         */
+        start,
+        /**
+         * position after last track to include in slice
+         */
+        end,
+      }: {
+        start: number;
+        end: number;
+      }): Promise<Models.TlTrack[]>;
+      // ----------------- OPTIONS -----------------
+      getConsume(): Promise<boolean>;
+      /**
+       * Set consume mode.
+       *
+       *   True = Tracks are removed from the tracklist when they have been
+       *   played.
+       *   False = Tracks are not removed from the tracklist.
+       */
+      setConsume({ value }: { value: boolean }): void;
+      getRandom(): Promise<boolean>;
+      /**
+       * Set random mode.
+       *
+       *   True = Tracks are selected at random from the tracklist.
+       *   False = Tracks are played in the order of the tracklist.
+       */
+      setRandom({ value }: { value: boolean }): void;
+      getRepeat(): Promise<boolean>;
+      /**
+       * Set repeat mode.
+       *
+       *   To repeat a single track, set both repeat and single.
+       */
+      setRepeat({ value }: { value: boolean }): void;
+      getSingle(): Promise<boolean>;
+      /**
+       * Set single mode.
+       *
+       *   True = Playback is stopped after current song, unless in repeat mode.
+       *   False = Playback continues after current song.
+       */
+      setSingle({ value }: { value: boolean }): void;
+    }
+    export interface PlaybackController {
+      // @TODO Finish
+
+      // ----------------- PLAYBACK CONTROL -----------------
+      /**
+       * Play the given track, or if the given tl_track and tlid is None, play the
+       * currently active track.
+       *
+       * Note that the track must already be in the tracklist.
+       *
+       * Deprecated since version 3.0: The tl_track argument. Use tlid instead.
+       *
+       * Parameters tl_track (mopidy.models.TlTrack or None) â€“ track to play
+       *
+       *   tlid (int or None) â€“ TLID of the track to play
+       *
+       */
+      play({
+        track,
+        tlid,
+      }: {
+        track?: Models.Track;
+        tlid?: number;
+      }): Promise<void>;
+      /**
+       * Change to the next track.
+       *
+       * The current playback state will be kept. If it was playing, playing will
+       * continue. If it was paused, it will still be paused, etc.
+       */
+      next(): Promise<void>;
+      /**
+       * Change to the previous track.
+       *
+       * The current playback state will be kept. If it was playing, playing will
+       * continue. If it was paused, it will still be paused, etc.
+       */
+      previous(): Promise<void>;
+      /**
+       * Stop playing.
+       */
+      stop(): Promise<void>;
+      /**
+       * Pause playback.
+       */
+      pause(): Promise<void>;
+      /**
+       * If paused, resume playing the current track.
+       */
+      resume(): Promise<void>;
+      /**
+       * Seeks to time position given in milliseconds.
+       *
+       *   Parameters
+       *     time_position (int) â€“ time position in milliseconds
+       *
+       *   Return type
+       *    True if successful, else False
+       */
+      seek({ time_position }: { time_position: number }): Promise<boolean>;
+      // ----------------- CURRENT TRACK -----------------
+      /**
+       * Get the currently playing or selected track.
+       */
+      getCurrentTlTrack(): Promise<Models.TlTrack | null>;
+      /**
+       * Get the currently playing or selected track.
+       *
+       * Extracted from get_current_tl_track() for convenience.
+       */
+      getCurrentTrack(): Promise<Models.Track | null>;
+      /**
+       * Get the current stream title or None.
+       */
+      getStreamTitle(): Promise<string | null>;
+      /**
+       * Get time position in milliseconds.
+       */
+      getTimePosition(): Promise<number | null>;
+      // ----------------- PLAYBACK STATES -----------------
+      /**
+       * Get The playback state.
+       */
+      getState(): Promise<PlaybackState>;
+      /**
+       * Set the playback state. See
+       * https://docs.mopidy.com/en/latest/api/core/#mopidy.core.PlaybackController.set_state
+       * for possible states and transitions
+       */
+      setState({ new_state }: { new_state: PlaybackState }): Promise<void>;
+    }
+    export interface LibraryController {
+      /**
+       * Browse directories and tracks at the given uri.
+       *
+       * uri is a string which represents some directory belonging to a backend.
+       * To get the intial root directories for backends pass None as the URI.
+       *
+       * @returns a list of mopidy.models.Ref objects for the directories and
+       * tracks at the given uri.
+       *
+       * The Ref objects representing tracks keep the trackâ€™s original URI. A
+       * matching pair of objects can look like this:
+       *
+       *    Track(uri='dummy:/foo.mp3', name='foo', artists=..., album=...)
+       *    Ref.track(uri='dummy:/foo.mp3', name='foo')
+       *
+       * The Ref objects representing directories have backend specific URIs.
+       * These are opaque values, so no one but the backend that created them
+       * should try and derive any meaning from them. The only valid exception to
+       * this is checking the scheme, as it is used to route browse requests to
+       * the correct backend.
+       *
+       * For example, the dummy libraryâ€™s /bar directory could be returned like
+       * this:
+       *
+       *    Ref.directory(uri='dummy:directory:/bar', name='bar')
+       *
+       */
+      browse({ uri }: { uri: URI }): Promise<Models.Ref[]>;
+      /**
+       * Search the library for tracks where `field` contains `values`.
+       *
+       * `field` can be one of `uri`, `track_name`, `album`, `artist`, `albumartist`,
+       * `composer`, `performer`, `track_no`, `genre`, `date`, `comment`, or `any`.
+       *
+       * If `uris` is given, the search is limited to results from within the URI
+       * roots. For example passing `uris=['file:']` will limit the search to the
+       * local backend.
+       *
+       * Examples:
+       *
+       *     # Returns results matching 'a' in any backend
+       *     search({'any': ['a']})
+       *
+       *     # Returns results matching artist 'xyz' in any backend
+       *     search({'artist': ['xyz']})
+       *
+       *     # Returns results matching 'a' and 'b' and artist 'xyz' in any
+       *     # backend
+       *     search({'any': ['a', 'b'], 'artist': ['xyz']})
+       *
+       *     # Returns results matching 'a' if within the given URI roots
+       *     # "file:///media/music" and "spotify:"
+       *     search({'any': ['a']}, uris=['file:///media/music', 'spotify:'])
+       *
+       *     # Returns results matching artist 'xyz' and 'abc' in any backend
+       *     search({'artist': ['xyz', 'abc']})
+       *
+       */
+      search({
+        query,
+        uris,
+        exact,
+      }: {
+        query: Query;
+        uris?: string[];
+        exact?: boolean;
+      }): Promise<Models.SearchResult[]>;
+      /**
+       * Lookup the images for the given URIs
+       *
+       * Backends can use this to return image URIs for any URI they know about be
+       * it tracks, albums, playlists. The lookup result is a dictionary mapping
+       * the provided URIs to lists of images.
+       *
+       * Unknown URIs or URIs the corresponding backend couldnâ€™t find anything for
+       * will simply return an empty list for that URI.
+       *
+       * @returns {uri: tuple of mopidy.models.Image}
+       *
+       */
+      getImages({
+        /**
+         * list of URIs to find images for
+         */
+        uris,
+      }: {
+        uris: string[];
+      }): Promise<{ [index: string]: Models.Image[] }>;
+    }
+    export interface PlaylistsController {}
+    export interface MixerController {}
+    export interface HistoryController {}
+    export interface Core {
+      PlaybackState: IPlaybackState;
+    }
+    class Mopidy {
+      // ----------------- MOPIDY.JS-SPECIFIC API -----------------
+
+      /**
+       * Mopidy.js is a JavaScript library for controlling a Mopidy music server.
+       *
+       * The library makes Mopidy's core API available from browsers and Node.js
+       * programs, using JSON-RPC over a WebSocket to communicate with Mopidy.
+       *
+       * This library is the foundation of most Mopidy web clients.
+       */
+      constructor(options: Options);
+      /**
+       * Explicit connect function for when autoConnect:false is passed to
+       * constructor.
+       */
+      connect(): Promise<void>;
+      /**
+       * Close the WebSocket without reconnecting. Letting the object be garbage
+       * collected will have the same effect, so this isn't strictly necessary.
+       */
+      close(): Promise<void>;
+
+      // ----------------- EVENT SUBSCRIPTION -----------------
+      on<
+        TEvent extends keyof StrictEvents,
+        TListener extends StrictEvents[TEvent]
+      >(event: TEvent, listener: TListener): void;
+
+      off(): void;
+      off<
+        TEvent extends keyof StrictEvents,
+        TListener extends StrictEvents[TEvent]
+      >(event: TEvent, listener?: TListener): void;
+
+      // ----------------- CORE API -----------------
+      // https://docs.mopidy.com/en/latest/api/core/#module-mopidy.core
+      core: Core;
+      /**
+       * Manages everything related to the list of tracks we will play. See
+       * TracklistController. Undefined before Mopidy connects.
+       */
+      tracklist: TracklistController | undefined;
+      /**
+       * Manages playback state and the current playing track. See
+       * PlaybackController. Undefined before Mopidy connects.
+       */
+      playback: PlaybackController | undefined;
+      /**
+       * Manages the music library, e.g. searching and browsing for music. See
+       * LibraryController. Undefined before Mopidy connects.
+       */
+      library: LibraryController | undefined;
+      /**
+       * Manages stored playlists. See PlaylistsController. Undefined before
+       * Mopidy connects.
+       */
+      playlists: PlaylistsController | undefined;
+      /**
+       * Manages volume and muting. See MixerController. Undefined before Mopidy
+       * connects.
+       */
+      mixer: MixerController | undefined;
+      /**
+       * Keeps record of what tracks have been played. See HistoryController.
+       * Undefined before Mopidy connects.
+       */
+      history: HistoryController | undefined;
+
+      // @TODO
+      // CoreListener
+      // Core
+
+      /**
+       * Get list of URI schemes we can handle
+       */
+      getUriSchemes(): Promise<string[]>;
+      /**
+       * Get version of the Mopidy core API
+       */
+      getVersion(): Promise<string>;
+    }
+
+    export = Mopidy;
+  }


### PR DESCRIPTION
This combines the efforts from #27 and #33, plus some additional fixes.

- Initial TypeScript definitions by altano
- Improved TypeScript definitions by whomwah
- Fix time{P => _p}osition in TypeScript definitions
- Publish TypeScript definitions
- Format TypeScript definitions with Prettier
- Use 'x?: X' instead of 'x: X | undefined'
- SearchResult.{tracks,artists,albums} are always arrays, not undefined
- Update changelog

Fixes #27
Fixes #33
