### PR TITLE
Revert to using Mopidy for top-most namespace

### DIFF
--- a/src/mopidy.d.ts
+++ b/src/mopidy.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Mopidy.js v1.1.0, Mopidy v3.0.2 WebSocket API
+// Type definitions for Mopidy.js v1.2.0, Mopidy v3.0.2 WebSocket API
 
 export = Mopidy;
 
@@ -13,7 +13,7 @@ declare class Mopidy {
    *
    * This library is the foundation of most Mopidy web clients.
    */
-  constructor(options: mopidy.Options);
+  constructor(options: Mopidy.Options);
   /**
    * Explicit connect function for when autoConnect:false is passed to
    * constructor.
@@ -27,15 +27,15 @@ declare class Mopidy {
 
   // ----------------- EVENT SUBSCRIPTION -----------------
 
-  on<K extends keyof mopidy.StrictEvents>(
+  on<K extends keyof Mopidy.StrictEvents>(
     name: K,
-    listener: mopidy.StrictEvents[K]
+    listener: Mopidy.StrictEvents[K]
   ): this;
 
   off(): void;
-  off<K extends keyof mopidy.StrictEvents>(
+  off<K extends keyof Mopidy.StrictEvents>(
     name: K,
-    listener: mopidy.StrictEvents[K]
+    listener: Mopidy.StrictEvents[K]
   ): this;
 
   // ----------------- CORE API -----------------
@@ -44,32 +44,32 @@ declare class Mopidy {
    * Manages everything related to the list of tracks we will play. See
    * TracklistController. Undefined before Mopidy connects.
    */
-  tracklist?: mopidy.core.TracklistController;
+  tracklist?: Mopidy.core.TracklistController;
   /**
    * Manages playback state and the current playing track. See
    * PlaybackController. Undefined before Mopidy connects.
    */
-  playback?: mopidy.core.PlaybackController;
+  playback?: Mopidy.core.PlaybackController;
   /**
    * Manages the music library, e.g. searching and browsing for music. See
    * LibraryController. Undefined before Mopidy connects.
    */
-  library?: mopidy.core.LibraryController;
+  library?: Mopidy.core.LibraryController;
   /**
    * Manages stored playlists. See PlaylistsController. Undefined before
    * Mopidy connects.
    */
-  playlists?: mopidy.core.PlaylistsController;
+  playlists?: Mopidy.core.PlaylistsController;
   /**
    * Manages volume and muting. See MixerController. Undefined before Mopidy
    * connects.
    */
-  mixer?: mopidy.core.MixerController;
+  mixer?: Mopidy.core.MixerController;
   /**
    * Keeps record of what tracks have been played. See HistoryController.
    * Undefined before Mopidy connects.
    */
-  history?: mopidy.core.HistoryController;
+  history?: Mopidy.core.HistoryController;
 
   /**
    * Get list of URI schemes we can handle
@@ -81,7 +81,7 @@ declare class Mopidy {
   getVersion(): Promise<string>;
 }
 
-declare namespace mopidy {
+declare namespace Mopidy {
   type ValueOf<T> = T[keyof T];
   type URI = string;
 


### PR DESCRIPTION
Addressing issue: https://github.com/mopidy/mopidy.js/issues/40

Small change to revert back to using `Mopidy` as top level namespace. Means we can just use:

```
import Mopidy from 'mopidy'
```

to get back to seeing:

<img width="978" alt="Screenshot 2021-05-06 at 14 35 12" src="https://user-images.githubusercontent.com/2031/117307373-6d6b7700-ae78-11eb-8a19-9df38c7564ee.png">
