### PR TITLE
Minor typing improvements for Mopidy constructor

### DIFF
--- a/src/mopidy.d.ts
+++ b/src/mopidy.d.ts
@@ -13,7 +13,7 @@ declare class Mopidy {
    *
    * This library is the foundation of most Mopidy web clients.
    */
-  constructor(options: Mopidy.Options);
+  constructor(options?: Mopidy.Options);
   /**
    * Explicit connect function for when autoConnect:false is passed to
    * constructor.
@@ -96,7 +96,7 @@ declare namespace Mopidy {
      * In a non-browser environment, where document.location isn't available, it
      * defaults to ws://localhost/mopidy/ws.
      */
-    webSocketUrl: string;
+    webSocketUrl?: string;
     /**
      * Whether or not to connect to the WebSocket on instance creation. Defaults
      * to true.


### PR DESCRIPTION
The options parameter is optional, as documented by the readme and
provided for by the code. Additionally, the websocket URL parameter is
also optional for similar reasons.