### PR TITLE
Allow browse to be null

### DIFF
--- a/src/mopidy.d.ts
+++ b/src/mopidy.d.ts
@@ -1179,7 +1179,7 @@ declare namespace Mopidy {
         /**
          * URI to browse
          */
-        uri: URI;
+        uri: URI | null;
       }): Promise<models.Ref<any>[]>;
 
       /**


### PR DESCRIPTION
This will allow the getBrowse to request top level file list.